### PR TITLE
07 usersテーブルに管理者と一般を表すカラムを追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@
 #  id               :bigint           not null, primary key
 #  crypted_password :string(255)
 #  email            :string(255)      not null
-#  role             :integer          default(0), not null
+#  role             :integer          default("general"), not null
 #  salt             :string(255)
 #  user_name        :string(255)      not null
 #  created_at       :datetime         not null
@@ -24,4 +24,7 @@ class User < ApplicationRecord
   validates :password, length: { minimum: 4 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
+
+  # 一般ユーザーか管理者の判別
+  enum role: { general: 0, admin: 1 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@
 #  id               :bigint           not null, primary key
 #  crypted_password :string(255)
 #  email            :string(255)      not null
+#  role             :integer          default(0), not null
 #  salt             :string(255)
 #  user_name        :string(255)      not null
 #  created_at       :datetime         not null

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,5 +1,5 @@
 ENV.each { |k, v| env(k, v) }
-set :output, error: 'log/crontab_error.log', standard: 'log/crontab.log' # 
+set :output, error: 'log/crontab_error.log', standard: 'log/crontab.log'
 set :environment, :development
 
 # 毎週日曜日、月曜日、火曜日の朝８時に、YouTube動画を更新

--- a/db/migrate/20230722035511_add_role_to_users.rb
+++ b/db/migrate/20230722035511_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :role, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_07_080508) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_22_035511) do
   create_table "teams", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -24,6 +24,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_07_080508) do
     t.string "user_name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "role", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["user_name"], name: "index_users_on_user_name", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,4 +7,5 @@
 #   Character.create(name: "Luke", movie: movies.first)
 
 # require './db/seeds/01_league_category'
+require './db/seeds/01_user'
 require './db/seeds/02_team'

--- a/db/seeds/01_user.rb
+++ b/db/seeds/01_user.rb
@@ -1,0 +1,19 @@
+User.create(
+  user_name: 'admin',
+  email: 'admin@example.com',
+  password: 'password',
+  password_confirmation: 'password',
+  role: 1
+)
+
+puts 'Start inserting seed "users" ...'
+10.times do
+  user = User.create(
+    user_name: Faker::Internet.unique.user_name,
+    email: Faker::Internet.unique.email,
+    password: 'password',
+    password_confirmation: 'password',
+    role: 0
+  )
+  puts "\"#{user.user_name}\" has created!"
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,7 +5,7 @@
 #  id               :bigint           not null, primary key
 #  crypted_password :string(255)
 #  email            :string(255)      not null
-#  role             :integer          default(0), not null
+#  role             :integer          default("general"), not null
 #  salt             :string(255)
 #  user_name        :string(255)      not null
 #  created_at       :datetime         not null

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,6 +5,7 @@
 #  id               :bigint           not null, primary key
 #  crypted_password :string(255)
 #  email            :string(255)      not null
+#  role             :integer          default(0), not null
 #  salt             :string(255)
 #  user_name        :string(255)      not null
 #  created_at       :datetime         not null

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,7 +5,7 @@
 #  id               :bigint           not null, primary key
 #  crypted_password :string(255)
 #  email            :string(255)      not null
-#  role             :integer          default(0), not null
+#  role             :integer          default("general"), not null
 #  salt             :string(255)
 #  user_name        :string(255)      not null
 #  created_at       :datetime         not null

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,6 +5,7 @@
 #  id               :bigint           not null, primary key
 #  crypted_password :string(255)
 #  email            :string(255)      not null
+#  role             :integer          default(0), not null
 #  salt             :string(255)
 #  user_name        :string(255)      not null
 #  created_at       :datetime         not null


### PR DESCRIPTION
## 概要
- enumを利用して管理者・一般を表す 2ad4833e4e1a767df0956b1f9cc9e8a1dbb55681
- usersテーブルのseedファイルを作成 99beb0e0f375cef9ca497227f02b24399497dc15

## 確認方法

1. カラムを追加したので `bin/rails db:migrate` を実行してください

## チェックリスト

- [x] Lint のチェックをパスした
- [x] 必要なドキュメントを作成した

## コメント
close #11 