### PR TITLE
30 本番環境ではアバター画像の保存先でAmazon S3を使用するように設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,6 @@ gem 'bootsnap', require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem 'image_processing', '~> 1.2'
 
-
 # 認証
 gem 'sorcery'
 
@@ -84,6 +83,8 @@ gem 'meta-tags'
 
 # seedファイルのフェイクデータ
 gem 'faker'
+
+gem 'fog-aws'
 
 group :development, :test do
   gem 'annotate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,7 @@ GEM
       rubocop
       smart_properties
     erubi (1.12.0)
+    excon (0.100.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -174,6 +175,22 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
     ffi (1.15.5)
+    fog-aws (3.19.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+    fog-core (2.3.0)
+      builder
+      excon (~> 0.71)
+      formatador (>= 0.2, < 2.0)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.4)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (1.1.0)
     gems (1.2.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
@@ -245,6 +262,9 @@ GEM
     meta-tags (2.18.0)
       actionpack (>= 3.2.0, < 7.1)
     method_source (1.0.0)
+    mime-types (3.5.0)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.0808)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
     minitest (5.18.1)
@@ -449,6 +469,7 @@ DEPENDENCIES
   erb_lint
   factory_bot_rails
   faker
+  fog-aws
   google-api-client
   jbuilder
   jsbundling-rails

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -4,8 +4,11 @@ class AvatarUploader < CarrierWave::Uploader::Base
   # include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  if Rails.env.development? || Rails.env.test?
+    storage :file
+  else
+    storage :fog
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,22 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+CarrierWave.configure do |config|
+  if Rails.env.production? # 本番環境の場合はS3へアップロード
+    config.storage :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_directory  = 'league-highlight-rails-avatar' # バケット名
+    config.fog_public = false
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV['S3_ACCESS_KEY_ID'], # アクセスキー
+      aws_secret_access_key: ENV['S3_SECRET_ACCESS_KEY'], # シークレットアクセスキー
+      region: 'ap-northeast-1', # リージョン
+      path_style: true
+    }
+  else # 本番環境以外の場合はアプリケーション内にアップロード
+    config.storage :file
+    config.enable_processing = false if Rails.env.test?
+  end
+end


### PR DESCRIPTION
## 概要
- 本番環境ではアバター画像の保存先でAmazon S3を使用するように設定 bcdd2abdd2b0b2450a5768f2d635f9d3344b44c8
- gem 'fog-aws'を追加

## 確認方法


1. Gem を追加したので `bundle install` を実行してください

## チェックリスト

- [x] Lint のチェックをパスした


## コメント
close #57 