### PR TITLE
32 YouTube APIに関係するメソッドを修正

### DIFF
--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -46,7 +46,8 @@ class Video < ApplicationRecord
         video_duration: "medium",
         order: 'relevance',
         published_after: after.iso8601,
-        published_before: before.iso8601
+        published_before: before.iso8601,
+        region_code: 'JP'
       }
       response = youtube_service.list_searches(:snippet, **opt)
 


### PR DESCRIPTION
## 概要
- HerokuではリージョンがUSになっており、YouTube API通信で動画取得をする際に、該当の動画を見つけることができないため、リージョンをJPに設定した。b17a261146c208034c9066cba42b4c308acc49eb

## チェックリスト
- [x] Lint のチェックをパスした

## コメント
close #60 