### PR TITLE
33 動画保存のrakeタスクを作成

### DIFF
--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,0 +1,6 @@
+namespace :scheduler do
+  desc "YouTubeから動画を取得し、保存する"
+  task fetch_and_save_videos: :environment do
+    Video.fetch_and_save_videos
+  end
+end


### PR DESCRIPTION
## 概要

Herokuではgem 'whenever'が使用できない為、rakeタスクを作成 e5d52f27cc02356ca41d2929fa5d5b262d9733c9


## チェックリスト

- [x] Lint のチェックをパスした

## コメント
close #64 