### PR TITLE
YouTube APIの検索キーワードを更新

### DIFF
--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -39,7 +39,7 @@ class Video < ApplicationRecord
     Team.find_each do |team|
       # YouTubeの動画検索を行う
       opt = {
-        q: "#{team.name} ハイライト",
+        q: "イングランド サッカー #{team.name} ハイライト プレミアリーグ",
         channel_id: 'UCJ-l-sMQFHogSy8KXRyMIRA',
         type: 'video',
         max_results: 50,


### PR DESCRIPTION
## 概要
現在サッカーとは関係ない動画まで取得されてしまうため以下の修正を行なった。
動画保存をするメソッド内で、YouTube APIのキーワード検索の部分を修正 cc9d9a8a27f63f7a7b12fcee67dae07bd25b6ca3

[![Image from Gyazo](https://i.gyazo.com/79e9db6b1f5cb0a7b78c696243f54962.png)](https://gyazo.com/79e9db6b1f5cb0a7b78c696243f54962)

## チェックリスト

- [x] Lint のチェックをパスした

## コメント
close #68 